### PR TITLE
Expose IsNew() access method to return value from gorilla/sessions IsNew

### DIFF
--- a/sessions.go
+++ b/sessions.go
@@ -70,6 +70,8 @@ type Session interface {
 	Flashes(vars ...string) []interface{}
 	// Options sets confuguration for a session.
 	Options(Options)
+	// IsNew() returns true if the session is new.
+	IsNew() bool
 }
 
 // Sessions is a Middleware that maps a session.Session service into the Martini handler chain.
@@ -143,6 +145,10 @@ func (s *session) Options(options Options) {
 		Secure:   options.Secure,
 		HttpOnly: options.HttpOnly,
 	}
+}
+
+func (s *session) IsNew() bool {
+	return s.Session().IsNew
 }
 
 func (s *session) Session() *sessions.Session {


### PR DESCRIPTION
This change is needed to avoid returning true from IsAuthenticated() on the first API access after a session is expired.
This was tested using yosssi/boltstore for session cookies, which correctly return the flag IsNew true from New() for an expired session.
However, it takes another round of middleware access for IsAuthenticated() to fail with the code before this change.
https://github.com/martini-contrib/sessionauth/issues/22