### PR TITLE
Changed the way session.Get() works to avoid returning an interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ func main() {
 		return v
 	})
 
-  m.Run()
+	m.Run()
 }
 
 ~~~

--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ func main() {
 	})
 
 	m.Get("/get", func(session sessions.Session) string {
-		v := session.Get("hello")
-		if v == nil {
-			return ""
+		v, valid := session.Get("hello").String()
+		if !valid {
+			return "Not a String"
 		}
-		return v.(string)
+		return v
 	})
 
   m.Run()

--- a/sessions.go
+++ b/sessions.go
@@ -177,7 +177,7 @@ func check(err error, l *log.Logger) {
 }
 
 // Int64 attempts to return an int64 from the session value.
-func (d *Data) Int64() (int64, bool) {
+func (d *Data) Int64() (i int64, valid bool) {
 	v := d.Value
 	switch v.(type) {
 	case int:
@@ -207,11 +207,11 @@ func (d *Data) Int64() (int64, bool) {
 	case float64:
 		return int64(v.(float64)), true
 	}
-	return 0, false
+	return i, false
 }
 
 // Float64 attempts to return a float64 from the session value.
-func (d *Data) Float64() (float64, bool) {
+func (d *Data) Float64() (f float64, valid bool) {
 	v := d.Value
 	switch v.(type) {
 	case float32:
@@ -241,25 +241,25 @@ func (d *Data) Float64() (float64, bool) {
 	case uint64:
 		return float64(v.(uint64)), true
 	}
-	return 0, false
+	return f, false
 }
 
 // String attempts to return a string from the session value.
-func (d *Data) String() (string, bool) {
+func (d *Data) String() (s string, valid bool) {
 	v := d.Value
 	switch v.(type) {
 	case string:
 		return v.(string), true
 	}
-	return "", false
+	return s, false
 }
 
 // Bool attempts to return a bool from the session value.
-func (d *Data) Bool() (bool, bool) {
+func (d *Data) Bool() (b bool, valid bool) {
 	v := d.Value
 	switch v.(type) {
 	case bool:
 		return v.(bool), true
 	}
-	return false, false
+	return b, false
 }

--- a/sessions.go
+++ b/sessions.go
@@ -20,11 +20,12 @@
 package sessions
 
 import (
+	"log"
+	"net/http"
+
 	"github.com/go-martini/martini"
 	"github.com/gorilla/context"
 	"github.com/gorilla/sessions"
-	"log"
-	"net/http"
 )
 
 const (
@@ -34,6 +35,16 @@ const (
 // Store is an interface for custom session stores.
 type Store interface {
 	sessions.Store
+}
+
+// Data stores a value in a session.
+//
+// The second return value for Int64(), Float64(), String() and Bool()
+// indicates weather the value was retrieved successfully and was valid.
+// If the session value's type is not valid for the function
+// (Int64 is used when the interface's type is bool), then false is returned.
+type Data struct {
+	Value interface{}
 }
 
 // Options stores configuration for a session or session store.
@@ -53,7 +64,7 @@ type Options struct {
 // Session stores the values and optional configuration for a session.
 type Session interface {
 	// Get returns the session value associated to the given key.
-	Get(key interface{}) interface{}
+	Get(key interface{}) *Data
 	// Set sets the session value associated to the given key.
 	Set(key interface{}, val interface{})
 	// Delete removes the session value associated to the given key.
@@ -105,8 +116,8 @@ type session struct {
 	written bool
 }
 
-func (s *session) Get(key interface{}) interface{} {
-	return s.Session().Values[key]
+func (s *session) Get(key interface{}) *Data {
+	return &Data{s.Session().Values[key]}
 }
 
 func (s *session) Set(key interface{}, val interface{}) {
@@ -163,4 +174,92 @@ func check(err error, l *log.Logger) {
 	if err != nil {
 		l.Printf(errorFormat, err)
 	}
+}
+
+// Int64 attempts to return an int64 from the session value.
+func (d *Data) Int64() (int64, bool) {
+	v := d.Value
+	switch v.(type) {
+	case int:
+		return int64(v.(int)), true
+	case int8:
+		return int64(v.(int8)), true
+	case int16:
+		return int64(v.(int16)), true
+	case int32:
+		return int64(v.(int32)), true
+	case int64:
+		return v.(int64), true
+
+	case uint:
+		return int64(v.(uint)), true
+	case uint8:
+		return int64(v.(uint8)), true
+	case uint16:
+		return int64(v.(uint16)), true
+	case uint32:
+		return int64(v.(uint32)), true
+	case uint64:
+		return int64(v.(uint64)), true
+
+	case float32:
+		return int64(v.(float32)), true
+	case float64:
+		return int64(v.(float64)), true
+	}
+	return 0, false
+}
+
+// Float64 attempts to return a float64 from the session value.
+func (d *Data) Float64() (float64, bool) {
+	v := d.Value
+	switch v.(type) {
+	case float32:
+		return float64(v.(float32)), true
+	case float64:
+		return v.(float64), true
+
+	case int:
+		return float64(v.(int)), true
+	case int8:
+		return float64(v.(int8)), true
+	case int16:
+		return float64(v.(int16)), true
+	case int32:
+		return float64(v.(int32)), true
+	case int64:
+		return float64(v.(int64)), true
+
+	case uint:
+		return float64(v.(uint)), true
+	case uint8:
+		return float64(v.(uint8)), true
+	case uint16:
+		return float64(v.(uint16)), true
+	case uint32:
+		return float64(v.(uint32)), true
+	case uint64:
+		return float64(v.(uint64)), true
+	}
+	return 0, false
+}
+
+// String attempts to return a string from the session value.
+func (d *Data) String() (string, bool) {
+	v := d.Value
+	switch v.(type) {
+	case string:
+		return v.(string), true
+	}
+	return "", false
+}
+
+// Bool attempts to return a bool from the session value.
+func (d *Data) Bool() (bool, bool) {
+	v := d.Value
+	switch v.(type) {
+	case bool:
+		return v.(bool), true
+	}
+	return false, false
 }

--- a/sessions.go
+++ b/sessions.go
@@ -182,6 +182,11 @@ func check(err error, l *log.Logger) {
 	}
 }
 
+// IsSet returns a bool indicating weather the value already exists.
+func (d *Data) IsSet() bool {
+	return d.Value != nil
+}
+
 // Int64 attempts to return an int64 from the session value.
 func (d *Data) Int64() (i int64, valid bool) {
 	v := d.Value

--- a/sessions.go
+++ b/sessions.go
@@ -78,7 +78,7 @@ type Session interface {
 	// Flashes returns a slice of flash messages from the session.
 	// A single variadic argument is accepted, and it is optional: it defines the flash key.
 	// If not defined "_flash" is used by default.
-	Flashes(vars ...string) []interface{}
+	Flashes(vars ...string) []*Data
 	// Options sets confuguration for a session.
 	Options(Options)
 }
@@ -141,9 +141,15 @@ func (s *session) AddFlash(value interface{}, vars ...string) {
 	s.written = true
 }
 
-func (s *session) Flashes(vars ...string) []interface{} {
+func (s *session) Flashes(vars ...string) (d []*Data) {
 	s.written = true
-	return s.Session().Flashes(vars...)
+
+	flashes := s.Session().Flashes(vars...)
+	for _, f := range flashes {
+		d = append(d, &Data{f})
+	}
+
+	return d
 }
 
 func (s *session) Options(options Options) {


### PR DESCRIPTION
To retrieve a session value, you now can use session.Get().String()/.Int64()/.Float64()/.Bool() to retreive the value not as an interface.

.String(), .Int64(), .Float64() and .Bool() all return a second argument which is a bool indicating weather the type was valid and was retreived successfully.

You also have the option of using session.Get().Value to get the original interface type.

An example of how you can use this is shown in the README.md update I made but here are a few more examples:

```go
// session.Set("foo", 63.22)
m.Get("/", func(session sessions.Session) string {
	foo, valid := session.Get("foo").Int64()
	if !valid {
		return "Foo hasn't been set or it is not numeric."
	}
	return fmt.Sprintf("Foo=%v", foo)
})
```

```go
// session.Set("foo", "bar")
m.Get("/", func(session sessions.Session) string {
	foo := session.Get("foo").Value
	if foo == nil {
		return "Foo hasn't been set."
	}
	return fmt.Sprintf("Foo=%v", foo)
})
```